### PR TITLE
Update permissions of ssh credentials in /root

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -16,6 +16,11 @@ if [ -d "/home/jenkins/.ssh-git" ]; then
 	chmod 600 /home/jenkins/.ssh-git/ssh-key.pub
 	chmod 700 /home/jenkins/.ssh-git
 fi
+if [ -d "/root/.ssh-git" ]; then
+	chmod 600 /root/.ssh-git/ssh-key
+	chmod 600 /root/.ssh-git/ssh-key.pub
+	chmod 700 /root/.ssh-git
+fi
 if [ -d "/home/jenkins/.gnupg" ]; then
 	chmod 600 /home/jenkins/.gnupg/pubring.gpg
 	chmod 600 /home/jenkins/.gnupg/secring.gpg


### PR DESCRIPTION
The changes made in https://github.com/fabric8io/jenkins-docker/commit/643f0ecd328e7c3d03c14c48d450e7ae303f3093 bring another path where ssh-key is located, /root instead of /home/jenkins. Therefore start.sh script has to be adapted to these changes, otherwise the problem of too open ssh key is appeared here:
`Permissions 0644 for '/root/.ssh-git/ssh-key' are too open`